### PR TITLE
Flip allow-alt-screen

### DIFF
--- a/st.lisp
+++ b/st.lisp
@@ -849,11 +849,11 @@ child process"
             1047
             1048)
            (when (and (eql arg 1049)
-                      (not (allow-alt-screen term)))
+                      (allow-alt-screen term))
              (tcursor (if set :cursor-save :cursor-load)
                       :term term))
            (when (member arg '(1049 47 1047))
-             (unless (allow-alt-screen term)
+             (when (allow-alt-screen term)
                (let ((alt (logtest (mode term) +mode-altscreen+)))
                  (when alt
                    (tclearregion 0 0 (1- (columns term)) (1- (rows term))


### PR DESCRIPTION
Currently, `allow-alt-screen=t` disables alt screen (correspond to `allow-alt-screen=0` in C version), which is somewhat confusing. This causes 3bst to disable alt screen by default, while the C version enables it by default. I thought this might be a mistake when translating the C code? This patch makes `allow-alt-screen=t` enables alt screen (therefore also enabled by default).